### PR TITLE
fixes for production errors

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,8 +3,6 @@ require 'rake/testtask'
 require 'robot-controller/tasks'
 require 'bundler'
 require 'rspec/core/rake_task'
-require 'yard'
-require 'yard/rake/yardoc_task'
 
 # Import external rake tasks
 Dir.glob('lib/tasks/*.rake').each { |r| import r }
@@ -31,6 +29,9 @@ end
 
 # Use yard to build docs
 begin
+  require 'yard'
+  require 'yard/rake/yardoc_task'
+
   project_root = File.expand_path(File.dirname(__FILE__))
   doc_dest_dir = File.join(project_root, 'doc')
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,7 +6,7 @@ set :rvm_ruby_string, 'ruby-1.9.3-p484' # dor-services requires 1.9.3
 
 set :application, 'was-seed-dissemination'
 set :repo_url, 'https://github.com/sul-dlss/was-seed-dissemination.git'
-set :branch, 'master'
+ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
 
 # Default branch is :master
 # ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call


### PR DESCRIPTION
This PR will fix the following error message in production. Note that this PR will not merge into `master` because its base is the current deployed production version 8873f5a. it also includes a397fa6b368e9127a1dcf44116e1d82d697abd54 which is a configuration change by Rosy.

```
rake aborted!
LoadError: cannot load such file -- yard
/home/lyberadmin/was-seed-diss/releases/20150821002428/Rakefile:6:in `require'
/home/lyberadmin/was-seed-diss/releases/20150821002428/Rakefile:6:in `<top (required)>'
(See full trace by running task with --trace)
```
