### PR TITLE
Yard fixes for deployment without development gems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,5 @@
 require 'rake'
 require 'rspec/core/rake_task'
-require 'yard'
-require 'robot-controller/tasks'
 
 task :default => :ci
 task :spec => :rspec
@@ -23,6 +21,9 @@ end
 
 # Use yard to build docs
 begin
+  require 'yard'
+  require 'yard/rake/yardoc_task'
+
   project_root = File.expand_path(File.dirname(__FILE__))
   doc_dest_dir = File.join(project_root, 'doc')
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,7 +6,7 @@ set :rvm_ruby_string, 'ruby-1.9.3-p484' # dor-services requires 1.9.3
 
 set :application, 'was-seed-dissemination'
 set :repo_url, 'https://github.com/sul-dlss/was-seed-dissemination.git'
-set :branch, 'master'
+ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
 
 # Default branch is :master
 # ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call


### PR DESCRIPTION
This PR makes `yard` optional since it's a development gem. Also fixes deploy so that it prompts for a branch.
